### PR TITLE
nginx: prefix tileman for ssl keys

### DIFF
--- a/nginx/ssl_params
+++ b/nginx/ssl_params
@@ -1,6 +1,6 @@
   ssl on;
-  ssl_certificate  /etc/ssl/certs/tile_cert.pem;
-  ssl_certificate_key  /etc/ssl/private/tile_privatekey.pem;
+  ssl_certificate  /etc/ssl/certs/tileman_cert.pem;
+  ssl_certificate_key  /etc/ssl/private/tileman_privatekey.pem;
   ssl_session_timeout  5m;
 
   ssl_protocols       SSLv3 TLSv1 TLSv1.1 TLSv1.2;


### PR DESCRIPTION
Change ssl key filename to prefix with tileman-

Signed-off-by: Hiroshi Miura miurahr@linux.com
