### PR TITLE
change cache key

### DIFF
--- a/nginx/conf.d/tileman.conf
+++ b/nginx/conf.d/tileman.conf
@@ -9,7 +9,10 @@ lua_package_path "/usr/local/share/lua/5.1/lib/?.lua;/usr/share/lua/5.1/lib/?.lu
 lua_package_cpath "/usr/lib/x86_64-linux-gnu/lua/5.1/?.so;/usr/lib/x86_64-linux-gnu/?.so;;";
 lua_shared_dict osm_tirex 10m;
 lua_socket_log_errors off;
-proxy_cache_path  /opt/tileman/cache  levels=1:2:2   keys_zone=tilecache:100m max_size=36G inactive=30d;
+#
+# a filesystem for using cache should be created with duplicated inodes
+# such as mkfs.ext4 -i 8192 /dev/sdc3
+proxy_cache_path  /srv/tilecache  levels=1:2:2  keys_zone=tilecache:100m max_size=36G inactive=30d;
 
 upstream openstreetmap_backend {
     server  a.tile.openstreetmap.org;

--- a/nginx/tileman_proxy_params
+++ b/nginx/tileman_proxy_params
@@ -5,9 +5,9 @@ proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X_FORWARDED_PROTO http;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header Host $http_host;
-proxy_cache       tilecache;
-proxy_cache_key "$scheme$host$request_uri";
-proxy_cache_valid  200 302  5d;
+proxy_cache      tilecache;
+proxy_cache_key  "$http_host$request_uri";
+proxy_cache_valid  200 302  7d;
 proxy_cache_valid  404      1m;
-proxy_redirect off;
+proxy_redirect   off;
 


### PR DESCRIPTION
- change cache key from $scheme$host$request_uri to
  $http_host$request_uri
  Users should remove old cache before upgrade
  tileman.

  ignore difference in schema http/https

  in default configuration cache key might be
  ex. KEY: openstreetmap_backend/15/2000/3000.png

- add warnig comment for filesystem inode parameter
  bacause of very small and huge number of cache object
  will made.

- Now cache will be active in 7days.
  follows OSM tile policy.

Signed-off-by: Hiroshi Miura <miurahr@linux.com>